### PR TITLE
Update psmodulecache version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,6 @@ runs:
         Write-Output "moduleversions=$($versionsString)" >> $env:GITHUB_OUTPUT
 
     - name: Install and cache PowerShell modules
-      uses: potatoqualitee/psmodulecache@v6.2
+      uses: potatoqualitee/psmodulecache@v6.2.1
       with:
         modules-to-cache: ${{ steps.parse-psmodules.outputs.moduleversions }}


### PR DESCRIPTION
Update 'psmodulecache' because current version uses a deprecated version of `actions/cache: v4.0.1` https://github.com/potatoqualitee/psmodulecache/releases/tag/v6.2.1