### PR TITLE
Introduce Pester tests for action

### DIFF
--- a/.github/workflows/.test.invoke-pester.yaml
+++ b/.github/workflows/.test.invoke-pester.yaml
@@ -1,0 +1,16 @@
+name: Invoke-Pester
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: Invoke-Pester -Output Detailed

--- a/.github/workflows/.test.invoke-pester.yaml
+++ b/.github/workflows/.test.invoke-pester.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Pester tests
         shell: pwsh

--- a/action.yaml
+++ b/action.yaml
@@ -26,15 +26,15 @@ runs:
         #* Register PS Gallery
         Register-PSGallery
 
-    - name: Parse PS Modules input
-      id: parse-psmodules
+    - name: Format PS Modules input
+      id: format-psmodulesinput
       shell: pwsh
       env:
         modules: ${{ inputs.modules }}
         actionPath: ${{ github.action_path }}
         debug: ${{ runner.debug }}
       run: |
-        #* Parse-PSModules
+        #* Format-PSModulesInput
 
         #* Set debug preference from runner configuration
         $DebugPreference = [bool]$env:debug ? "Continue" : "SilentlyContinue"
@@ -42,14 +42,14 @@ runs:
         #* Import module
         Import-Module "$($env:actionPath)/src/InstallPSModules.psm1" -Force
 
-        #* Parse PS Modules input
-        $modules = Parse-PSModules -Modules $env:modules
+        #* Format PS Modules input
+        $modulesString = Format-PSModulesInput -InputString $env:modules
 
-        #* Output module versions
-        Write-Output "moduleversions=$($versionsString)" >> $env:GITHUB_OUTPUT
+        #* Output modules string
+        Write-Output "modules-string=$($modulesString)" >> $env:GITHUB_OUTPUT
 
     - name: Install and cache PowerShell modules
       uses: potatoqualitee/psmodulecache@v6.2.1
       with:
-        modules-to-cache: ${{ steps.parse-psmodules.outputs.moduleversions }}
+        modules-to-cache: ${{ steps.format-psmodulesinput.outputs.modules-string }}
         updatable: true

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
-name: "Install PS Modules"
-description: "Installs PowerShell modules and versions. Uses caching to increase reliability"
+name: Install PS Modules
+description: Installs PowerShell modules and versions. Uses caching to increase reliability
 
 inputs:
   modules:
@@ -7,30 +7,45 @@ inputs:
     required: true
 
 runs:
-  using: "composite"
+  using: composite
   steps:
-    - name: Register PS repository
+    - name: Register-PSGallery
       shell: pwsh
+      env:
+        actionPath: ${{ github.action_path }}
+        debug: ${{ runner.debug }}
       run: |
-        $psRepository = Get-PSRepository -Name PSGallery -ErrorAction Ignore
-        if (!$psRepository -or !$psRepository.Trusted) {
-            Unregister-PSRepository PSGallery -ErrorAction Ignore
-            Register-PSRepository -Default -InstallationPolicy Trusted
-        }
+        #* Register-PSGallery
 
-    - name: Parse PowerShell Modules versions
+        #* Set debug preference from runner configuration
+        $DebugPreference = [bool]$env:debug ? "Continue" : "SilentlyContinue"
+
+        #* Import module
+        Import-Module "$($env:actionPath)/src/InstallPSModules.psm1" -Force
+
+        #* Register PS Gallery
+        Register-PSGallery
+
+    - name: Parse PS Modules input
       id: parse-psmodules
       shell: pwsh
       env:
-        moduleversions: ${{ inputs.modules }}
+        modules: ${{ inputs.modules }}
+        actionPath: ${{ github.action_path }}
+        debug: ${{ runner.debug }}
       run: |
-        $versionsString = $env:moduleversions -split "`n"
-        | ForEach-Object { $_ -replace " ", "" -replace ":latest$", "::" }
-        | Where-Object { $_ }
-        | ForEach-Object { if ($_ -notmatch ":") { "$_::" } else { $_ } }
-        | Sort-Object -Unique
-        | Join-String -Separator ','
+        #* Parse-PSModules
 
+        #* Set debug preference from runner configuration
+        $DebugPreference = [bool]$env:debug ? "Continue" : "SilentlyContinue"
+
+        #* Import module
+        Import-Module "$($env:actionPath)/src/InstallPSModules.psm1" -Force
+
+        #* Parse PS Modules input
+        $modules = Parse-PSModules -Modules $env:modules
+
+        #* Output module versions
         Write-Output "moduleversions=$($versionsString)" >> $env:GITHUB_OUTPUT
 
     - name: Install and cache PowerShell modules

--- a/src/InstallPSModules.psm1
+++ b/src/InstallPSModules.psm1
@@ -1,0 +1,24 @@
+function Register-PSGallery {
+    [CmdletBinding()]
+    param ()
+    $psRepository = Get-PSRepository -Name PSGallery -ErrorAction Ignore
+    if (!$psRepository -or !$psRepository.Trusted) {
+        Unregister-PSRepository PSGallery -ErrorAction Ignore
+        Register-PSRepository -Default -InstallationPolicy Trusted
+    }
+}
+
+function Format-PSModuleInput {
+    [CmdletBinding()]
+    param (
+        [string]$Modules
+    )
+
+    $modulesString = $Modules -split "`n"
+    | ForEach-Object { $_ -replace " ", "" -replace ":latest$", "::" }
+    | Where-Object { $_ }
+    | ForEach-Object { if ($_ -notmatch ":") { "$_::" } else { $_ } }
+    | Join-String -Separator ','
+    
+    return $modulesString
+}

--- a/src/InstallPSModules.psm1
+++ b/src/InstallPSModules.psm1
@@ -8,13 +8,13 @@ function Register-PSGallery {
     }
 }
 
-function Format-PSModuleInput {
+function Format-PSModulesInput {
     [CmdletBinding()]
     param (
-        [string]$Modules
+        [string]$InputString
     )
 
-    $modulesString = $Modules -split "`n"
+    $modulesString = $InputString -split "`n"
     | ForEach-Object { $_ -replace " ", "" -replace ":latest$", "::" }
     | Where-Object { $_ }
     | ForEach-Object { if ($_ -notmatch ":") { "$_::" } else { $_ } }

--- a/src/tests/Format-PSModuleInput.tests.ps1
+++ b/src/tests/Format-PSModuleInput.tests.ps1
@@ -2,7 +2,7 @@ BeforeAll {
     Import-Module $PSScriptRoot/../InstallPSModules.psm1 -Force
 }
 
-Describe "Format-PSModuleInput" {
+Describe "Format-PSModulesInput" {
     It "Should handle <scenario> correctly" -TestCases @(
         @{
             scenario = "Empty string input"
@@ -37,7 +37,7 @@ Az.Storage
     ) {
         param($modules, $expected)
 
-        $result = Format-PSModuleInput -Modules $modules
+        $result = Format-PSModulesInput -InputString $modules
 
         $result | Should -BeExactly $expected
     }

--- a/src/tests/Format-PSModuleInput.tests.ps1
+++ b/src/tests/Format-PSModuleInput.tests.ps1
@@ -1,0 +1,44 @@
+BeforeAll {
+    Import-Module $PSScriptRoot/../InstallPSModules.psm1 -Force
+}
+
+Describe "Format-PSModuleInput" {
+    It "Should handle <scenario> correctly" -TestCases @(
+        @{
+            scenario = "Empty string input"
+            modules  = ""
+            expected = ""
+        }
+        @{
+            scenario = "Single module with no version"
+            modules  = "Az.Accounts"
+            expected = "Az.Accounts::"
+        }
+        @{
+            scenario = "Single module with version"
+            modules  = "Az.Accounts:2.17.0"
+            expected = "Az.Accounts:2.17.0"
+        }
+        @{
+            scenario = "Single module with explicit latest version"
+            modules  = "Az.Accounts:latest"
+            expected = "Az.Accounts::"
+        }
+        @{
+            scenario = "Multiple modules with different formats"
+            modules  = @"
+Az.Accounts:2.17.0
+Az.Billing:2.0.3
+Pester:latest
+Az.Storage
+"@
+            expected = "Az.Accounts:2.17.0,Az.Billing:2.0.3,Pester::,Az.Storage::"
+        }
+    ) {
+        param($modules, $expected)
+
+        $result = Format-PSModuleInput -Modules $modules
+
+        $result | Should -BeExactly $expected
+    }
+}

--- a/src/tests/Register-PSGallery.tests.ps1
+++ b/src/tests/Register-PSGallery.tests.ps1
@@ -1,0 +1,31 @@
+BeforeAll {
+    Import-Module $PSScriptRoot/../InstallPSModules.psm1 -Force
+}
+
+Describe "Register-PSGallery" {
+    It "Should register PSGallery as trusted when Get-PSRepository returns null" {
+        InModuleScope InstallPSModules {
+            Mock -CommandName Get-PSRepository -MockWith { $null }
+            Mock -CommandName Unregister-PSRepository
+            Mock -CommandName Register-PSRepository
+
+            Register-PSGallery
+
+            Should -Invoke Get-PSRepository -Times 1 -Exactly
+            Should -Invoke Unregister-PSRepository -Times 1 -Exactly
+            Should -Invoke Register-PSRepository -Times 1 -Exactly
+        }
+    }
+    
+    # It "Should register PSGallery as trusted when not trusted from before" {
+    #     InModuleScope InstallPSModules {
+    #         Mock -CommandName Get-PSRepository -MockWith { @{} }
+    #         Mock -CommandName Unregister-PSRepository
+            
+    #         Register-PSGallery
+            
+    #         Should -Invoke Get-PSRepository -Times 1 -Exactly -ModuleName InstallPSModules
+    #         Should -Invoke Unregister-PSRepository -Times 1 -Exactly -ModuleName InstallPSModules
+    #     }
+    # }
+}

--- a/src/tests/Register-PSGallery.tests.ps1
+++ b/src/tests/Register-PSGallery.tests.ps1
@@ -14,12 +14,9 @@ Describe "Register-PSGallery" {
     }
 
     AfterEach {
+        Unregister-PSRepository -Name PSGallery
         if ($currentPSRepository) {
-            Unregister-PSRepository -Name PSGallery
             Register-PSRepository -Default -InstallationPolicy $currentPSRepository.InstallationPolicy
-        }
-        else {
-            Unregister-PSRepository -Name PSGallery
         }
     }
 


### PR DESCRIPTION
- **Temp**
- **Fix tests**
This pull request introduces new PowerShell helper functions for module input formatting and PSGallery registration, integrates them into the GitHub Action workflow, and adds comprehensive Pester tests for these utilities. The changes improve modularity, reliability, and test coverage for PowerShell module management in CI workflows.

### PowerShell Helper Functions

* Added `Register-PSGallery` and `Format-PSModuleInput` functions to `src/InstallPSModules.psm1` to handle PSGallery registration and module input formatting logic.

### GitHub Action Workflow Integration

* Updated `action.yaml` to use the new helper functions, refactored step names and environment variable usage, and improved debug handling. The module input parsing now leverages `Parse-PSModules` from the imported module.
* Added a new workflow file `.github/workflows/.test.invoke-pester.yaml` to run Pester tests on pull requests and workflow dispatch events.

### Test Coverage

* Added Pester tests for `Format-PSModuleInput` covering multiple input scenarios in `src/tests/Format-PSModuleInput.tests.ps1`.
* Added Pester tests for `Register-PSGallery` to verify PSGallery is registered as trusted in various conditions in `src/tests/Register-PSGallery.tests.ps1`.